### PR TITLE
Remove vendored stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 .PHONY: default test-dep test dep
 
-default: dep stdlib
+default: dep
 
 test-dep:
 	cd testdata/case/ruby-sample-0 && $(BUNDLE) install
@@ -25,13 +25,3 @@ test-gen-program:
 dep:
 	$(BUNDLE) install
 	cd yard && $(BUNDLE) install
-
-RUBY_VERSION ?= ruby-2.2.2
-RUBY_SOURCE_URL ?= http://cache.ruby-lang.org/pub/ruby/2.2/$(RUBY_VERSION).tar.gz
-stdlib: $(RUBY_VERSION) $(RUBY_VERSION)/.yardoc
-
-$(RUBY_VERSION):
-	[ -e $(RUBY_VERSION) ] || curl $(RUBY_SOURCE_URL) | tar -xz
-
-$(RUBY_VERSION)/.yardoc:
-	cp $(CURDIR)/.yardopts_ruby $(CURDIR)/$(RUBY_VERSION)/.yardopts && cd $(CURDIR)/$(RUBY_VERSION) && $(YARDOC)


### PR DESCRIPTION
Import `psych` directly rather than vendoring in the Ruby standard library.